### PR TITLE
[0.27.2] initial state callbacks fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 env:
   BUILD_TYPE: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to project will be documented in this file.
 
+## [0.27.2] - 2023-01-25
+### Fixed
+- onEntry and onState callbacks of initial HSM state are not called
+
 ## [0.27.1] - 2023-01-22
 ### Added
 - scxml2gen: new generate_code and generate_diagram API for usage from Python scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(hsmcpp)
 
-set(PROJECT_VERSION "0.27.1")
+set(PROJECT_VERSION "0.27.2")
 set(PROJECT_DESCRIPTION "C++ library for hierarchical state machines / finite state machines. Provides a code-free visual approach for defining state machine logic using GUI editors with automatic code and diagram generation. Check out https://hsmcpp.readthedocs.io for detailed documentation.")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
@@ -131,22 +131,11 @@ elseif (HSMBUILD_TARGET STREQUAL "library")
     # =============================================
     # Common modules
     if (NOT WIN32)
-    include(FindPkgConfig)
+        find_package(PkgConfig REQUIRED)
     endif()
 
     set(THREADS_PREFER_PTHREAD_FLAG TRUE)
     find_package (Threads REQUIRED)
-
-    if (HSMBUILD_DISPATCHER_GLIB)
-        pkg_check_modules(GLIB REQUIRED glib-2.0)
-        pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
-
-        set(GLIB_PKG_INCLUDE_DIRS ${GLIB_INCLUDE_DIRS}
-                                  ${GLIBMM_INCLUDE_DIRS})
-
-        set(GLIB_PKG_LDFLAGS ${GLIB_LDFLAGS}
-                             ${GLIBMM_LDFLAGS})
-    endif()
 
     add_subdirectory(tools/cmake)
     add_subdirectory(tools/scxml2gen)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Generic badge](https://img.shields.io/badge/changelog-v0.27.1-green.svg)](https://github.com/igor-krechetov/hsmcpp/blob/main/CHANGELOG.md)
+[![Generic badge](https://img.shields.io/badge/changelog-v0.27.2-green.svg)](https://github.com/igor-krechetov/hsmcpp/blob/main/CHANGELOG.md)
 [![Generic badge](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/igor-krechetov/hsmcpp/blob/main/LICENSE)
 [![Documentation Status](https://readthedocs.org/projects/hsmcpp/badge/?version=latest)](https://hsmcpp.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://github.com/igor-krechetov/hsmcpp/actions/workflows/build.yml/badge.svg)](https://github.com/igor-krechetov/hsmcpp/actions/workflows/build.yml)

--- a/examples/07_build/build_all.sh
+++ b/examples/07_build/build_all.sh
@@ -17,6 +17,7 @@ cp -R ../../../include ./hsmcpp/
 cp -R ../../../src ./hsmcpp/
 cp -R ../../../pkgconfig ./hsmcpp/
 cp -R ../../../tools ./hsmcpp/
+cp -R ../../../cmake ./hsmcpp/
 cp ../../../CMakeLists.txt ./hsmcpp/
 cd ./build
 cmake ..

--- a/examples/07_build/using_pkgconfig/CMakeLists.txt
+++ b/examples/07_build/using_pkgconfig/CMakeLists.txt
@@ -3,7 +3,7 @@ project(07_build_pkgconfig)
 set(BINARY_NAME "07_build_pkgconfig")
 set(CMAKE_CXX_STANDARD 11)
 
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 
 # Configure HSMCPP library. Settings must be set before calling find_package
 set(HSMCPP_CONFIG_VERBOSE ON CACHE BOOL "Enable internal HSM traces")

--- a/tests/02_substates.cpp
+++ b/tests/02_substates.cpp
@@ -357,7 +357,7 @@ TEST_F(ABCHsm, substate_entrypoints_substate)
     //-------------------------------------------
     // VALIDATION
     ASSERT_TRUE(compareStateLists(getActiveStates(), {AbcState::P1, AbcState::P2, AbcState::P3, AbcState::B}));
-    EXPECT_EQ(mStateCounterA, 0);
+    EXPECT_EQ(mStateCounterA, 1);
     EXPECT_EQ(mStateCounterB, 1);
     EXPECT_EQ(mStateCounterC, 0);
 }
@@ -406,7 +406,7 @@ TEST_F(ABCHsm, substate_exit_single)
     // VALIDATION
     ASSERT_TRUE(compareStateLists(getActiveStates(), {AbcState::A}));
     EXPECT_EQ(mStateCounterA, 2);
-    EXPECT_EQ(mStateCounterAEnter, 1);
+    EXPECT_EQ(mStateCounterAEnter, 2);
     EXPECT_EQ(mStateCounterC, 1);
     EXPECT_EQ(mStateCounterCExit, 1);
     EXPECT_EQ(mTransitionCounterE3, 1);
@@ -491,7 +491,7 @@ TEST_F(ABCHsm, substate_exit_multiple_layers)
     //-------------------------------------------
     // VALIDATION
     EXPECT_TRUE(compareStateLists(getActiveStates(), {AbcState::A}));
-    EXPECT_EQ(mStateCounterA, 1);
+    EXPECT_EQ(mStateCounterA, 2);
     EXPECT_EQ(mStateCounterB, 1);
     EXPECT_EQ(mStateCounterC, 1);
     EXPECT_EQ(mStateCounterD, 1);

--- a/tests/04_multithreaded.cpp
+++ b/tests/04_multithreaded.cpp
@@ -9,10 +9,26 @@
 TEST_F(AsyncHsm, multithreaded_entrypoint_cancelation)
 {
     TEST_DESCRIPTION("entrypoint transitions should be atomic and can't be canceled");
+    /*
+    @startuml
+    left to right direction
+    title multithreaded_entrypoint_cancelation
+
+    state A #orange: onExit
+
+    A -[#green,bold]-> P1: NEXT_STATE
+    P1 -[#red,bold]-> C: EXIT_SUBSTATE
+    C --> A: NEXT_STATE
+    state P1 {
+        [*] --> B
+    }
+    P1 --> A : E3
+    @enduml
+    */
 
     //-------------------------------------------
     // PRECONDITIONS
-    registerState<AsyncHsm>(AsyncHsmState::A, this, &AsyncHsm::onStateChanged, nullptr, &AsyncHsm::onExit);
+    registerState<AsyncHsm>(AsyncHsmState::A, this, nullptr, nullptr, &AsyncHsm::onExit);
     registerState<AsyncHsm>(AsyncHsmState::B, this, &AsyncHsm::onStateChanged);
     registerState<AsyncHsm>(AsyncHsmState::C, this, &AsyncHsm::onStateChanged);
 
@@ -101,7 +117,7 @@ TEST_F(AsyncHsm, multithreaded_transition_from_interrupt)
     // PRECONDITIONS
     gAsyncHsmInstance = this;
 
-    registerState<AsyncHsm>(AsyncHsmState::A, this, &AsyncHsm::onStateChanged);
+    registerState(AsyncHsmState::A);
     registerState<AsyncHsm>(AsyncHsmState::B, this, &AsyncHsm::onStateChanged);
 
     registerTransition(AsyncHsmState::A, AsyncHsmState::B, AsyncHsmEvent::NEXT_STATE);
@@ -118,7 +134,7 @@ TEST_F(AsyncHsm, multithreaded_transition_from_interrupt)
     //-------------------------------------------
     // ACTIONS
     raise(SIGUSR1);
-    ASSERT_TRUE(waitAsyncOperation(200));
+    ASSERT_TRUE(waitAsyncOperation(1000));
 
     //-------------------------------------------
     // VALIDATION

--- a/tests/07_parallel.cpp
+++ b/tests/07_parallel.cpp
@@ -509,6 +509,31 @@ TEST_F(ABCHsm, parallel_transition_mult2one_02)
 TEST_F(ABCHsm, parallel_callbacks)
 {
     TEST_DESCRIPTION("*A -> B + C -> A: check that all callbacks are correctly executed");
+    /*
+    @startuml
+    left to right direction
+
+    state parallel_callbacks {
+        state A #orange : **onAEnter**\n**onA**\n**onAExit**
+        state B #LightGreen : **onBEnter**\n**onB**\nonBExit
+        state C #LightGreen : **onCEnter**\n**onC**\nonCExit
+
+        A -[#green,bold]-> B: E1
+        A -[#green,bold]-> C: E1
+        B --> A: E2
+        C --> A: E2
+        --
+        state "A" as 2_A #LightGreen : **onAEnter**\n**onA**\nonAExit
+        state "B" as 2_B #orange : onBEnter\nonB\n**onBExit**
+        state "C" as 2_C #orange : onCEnter\nonC\n**onCExit**
+
+        2_A --> 2_B: E1
+        2_A --> 2_C: E1
+        2_B -[#green,bold]-> 2_A: E2
+        2_C -[#green,bold]-> 2_A: E2
+    }
+    @enduml
+    */
 
     //-------------------------------------------
     // PRECONDITIONS
@@ -529,8 +554,8 @@ TEST_F(ABCHsm, parallel_callbacks)
     ASSERT_TRUE(transitionSync(AbcEvent::E1, HSM_WAIT_INDEFINITELY));
 
     ASSERT_TRUE(compareStateLists(getActiveStates(), {AbcState::B, AbcState::C}));
-    ASSERT_EQ(mStateCounterA, 0);
-    ASSERT_EQ(mStateCounterAEnter, 0);
+    ASSERT_EQ(mStateCounterA, 1);
+    ASSERT_EQ(mStateCounterAEnter, 1);
     ASSERT_EQ(mStateCounterAExit, 1);
     ASSERT_EQ(mTransitionCounterE1, 2);
 
@@ -539,8 +564,8 @@ TEST_F(ABCHsm, parallel_callbacks)
 
     //-------------------------------------------
     // VALIDATION
-    EXPECT_EQ(mStateCounterA, 1);
-    EXPECT_EQ(mStateCounterAEnter, 1);
+    EXPECT_EQ(mStateCounterA, 2);
+    EXPECT_EQ(mStateCounterAEnter, 2);
     EXPECT_EQ(mStateCounterAExit, 1);
     EXPECT_EQ(mStateCounterB, 1);
     EXPECT_EQ(mStateCounterBEnter, 1);
@@ -557,7 +582,18 @@ TEST_F(ABCHsm, parallel_selftransition)
 {
     TEST_DESCRIPTION("*A -> A + B: when we have both a regular and self-transition self-transition will"
                      " be excecuted first before exiting state");
+    /*
+    @startuml
+    left to right direction
+    title parallel_callbacks
 
+    state A #orange : **onAEnter**\n**onA**\n**onAExit**
+    state B #LightGreen : **onBEnter**\n**onB**\nonBExit
+
+    A -[#green,bold]-> A: **E1**
+    A -[#green,bold]-> B: **E1**
+    @enduml
+    */
     //-------------------------------------------
     // PRECONDITIONS
     registerState<ABCHsm>(AbcState::A, this, &ABCHsm::onA, &ABCHsm::onAEnter, &ABCHsm::onAExit);
@@ -576,8 +612,8 @@ TEST_F(ABCHsm, parallel_selftransition)
 
     //-------------------------------------------
     // VALIDATION
-    EXPECT_EQ(mStateCounterA, 0);
-    EXPECT_EQ(mStateCounterAEnter, 0);
+    EXPECT_EQ(mStateCounterA, 1);
+    EXPECT_EQ(mStateCounterAEnter, 1);
     EXPECT_EQ(mStateCounterAExit, 1);
     EXPECT_EQ(mTransitionCounterE1, 2);
 }
@@ -585,6 +621,19 @@ TEST_F(ABCHsm, parallel_selftransition)
 TEST_F(ABCHsm, parallel_selftransition_multiple)
 {
     TEST_DESCRIPTION("*A -> A + A: check that multiple self transitions are correctly handled");
+    /*
+    @startuml
+    left to right direction
+    title parallel_selftransition_multiple
+
+    state A #orange : **onAEnter**\n**onA**\nonAExit
+    state B : onBEnter\nonB\nonBExit
+
+    A -[#green,bold]-> A: E1 <<onE1Transition>>
+    A -[#green,bold]-> A: E1 <<onE2Transition>>
+    A --> B: E3
+    @enduml
+    */
 
     //-------------------------------------------
     // PRECONDITIONS
@@ -605,8 +654,8 @@ TEST_F(ABCHsm, parallel_selftransition_multiple)
 
     //-------------------------------------------
     // VALIDATION
-    EXPECT_EQ(mStateCounterA, 0);
-    EXPECT_EQ(mStateCounterAEnter, 0);
+    EXPECT_EQ(mStateCounterA, 1);
+    EXPECT_EQ(mStateCounterAEnter, 1);
     EXPECT_EQ(mStateCounterAExit, 0);
     EXPECT_EQ(mTransitionCounterE1, 1);
     EXPECT_EQ(mTransitionCounterE2, 1);


### PR DESCRIPTION
fix: onEntry and onState callbacks of initial HSM state are not called