### PR TITLE
Fix expiration time of timer being restarted

### DIFF
--- a/src/HsmEventDispatcherSTD.cpp
+++ b/src/HsmEventDispatcherSTD.cpp
@@ -200,8 +200,9 @@ void HsmEventDispatcherSTD::handleTimers() {
                 if (itTimeout != mRunningTimers.end()) {
                     if (true == handleTimerEvent(waitingTimerId)) {
                         // restart timer
+                        auto timer_interval = itTimeout->second.elapseAfter - itTimeout->second.startedAt;
                         itTimeout->second.startedAt = std::chrono::steady_clock::now();
-                        itTimeout->second.elapseAfter = itTimeout->second.startedAt + std::chrono::milliseconds(intervalMs);
+                        itTimeout->second.elapseAfter = itTimeout->second.startedAt + timer_interval;
                     } else {
                         // single shot timer. remove from queue
                         mRunningTimers.erase(itTimeout);


### PR DESCRIPTION
Solution to the issue presented in [This PR](https://github.com/igor-krechetov/hsmcpp/pull/8)

I had a bit of time and found the issue. If a timer expires, `intervalMs,` is <= 0. Then, the restarted timer will have a `elapseAfter` of **now** plus at most zero, therefore making it immediately expired. Then, the situation continues in the next timer thread loop, and as `intervalMs` is zero or less, the condition variable wait also immediately returns. This results in uncontrolled triggering of timer callbacks.