### PR TITLE
Fixed unused parameter compiler warnings/errors

### DIFF
--- a/tools/scxml2gen/template.cpp
+++ b/tools/scxml2gen/template.cpp
@@ -43,6 +43,9 @@ void @CLASS_NAME@::configureActions() {
 void @CLASS_NAME@::onTransitionFailed(const std::list<hsmcpp::StateID_t>& activeStates,
                                       const hsmcpp::EventID_t event,
                                       const hsmcpp::VariantVector_t& args) {
+    (void) activeStates;
+    (void) event;
+    (void) args;
     // do nothing
 }
 


### PR DESCRIPTION
The onTransitionFailed() method of the class template has unused parameters which can cause compiler errors.... or at least warnings.